### PR TITLE
chore: release 5.0.0-exodus.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ package-lock.json
 secp256k1-*.tgz
 yarn-error.log
 yarn.lock
+.DS_Store

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/secp256k1",
-  "version": "4.0.2-exodus.0",
+  "version": "5.0.0-exodus.0",
   "description": "This module provides native bindings to ecdsa secp256k1 functions",
   "keywords": [
     "ec",


### PR DESCRIPTION
Bump to `5.0.0`