### PR TITLE
refactor: drop bitcoinerlab

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -87,11 +87,11 @@ module.exports = {
   publicKeyCreate: function (output, seckey) {
     try {
       output.set(noble.getPublicKey(seckey, isCompressedPublicKey(output)))
-      return 0
     } catch (e) {
       console.error('publicKeyCreate failed', e)
       return 1
     }
+    return 0
   },
   publicKeyConvert: function (output, pubkey) {
     try {

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -130,16 +130,6 @@ module.exports = {
     }
     return 0
   },
-  ecdsaRecover: function (output, sig, recid, msg32) {
-    if (!_isSignature(sig)) return 1
-    try {
-      output.set(noble.recoverPublicKey(msg32, sig, recid, isCompressedPublicKey(output)))
-    } catch (e) {
-      console.error('ecdsaRecover failed', e)
-      return 2
-    }
-    return 0
-  },
   ecdsaVerify: function (sig, msg32, pubkey) {
     if (!_isSignature(sig)) return 1
     if (!_isPoint(pubkey)) return 2
@@ -150,5 +140,15 @@ module.exports = {
       console.error('ecdsaVerify failed', e)
       return 1
     }
+  },
+  ecdsaRecover: function (output, sig, recid, msg32) {
+    if (!_isSignature(sig)) return 1
+    try {
+      output.set(noble.recoverPublicKey(msg32, sig, recid, isCompressedPublicKey(output)))
+    } catch (e) {
+      console.error('ecdsaRecover failed', e)
+      return 2
+    }
+    return 0
   }
 }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -1,6 +1,5 @@
 // Pre-load elliptic as a backup
 const elliptic = require('./elliptic')
-const bitcoinerlab = require('@exodus/bitcoinerlab-secp256k1')
 const noble = require('@noble/secp256k1')
 
 const Errors = {
@@ -96,14 +95,12 @@ module.exports = {
   publicKeyConvert: function (output, pubkey) {
     try {
       output.set(
-        bitcoinerlab.pointCompress(pubkey, isCompressedPublicKey(output))
+        noble.Point.fromHex(pubkey).toRawBytes(isCompressedPublicKey(output))
       )
-      return 0
     } catch (e) {
-      console.error('publicKeyConvert failed', e)
-      if (e.message === Errors.EXPECTED_POINT) return 1
-      return 2
+      return 1
     }
+    return 0
   },
   publicKeyNegate: function (output, pubkey) {
     return elliptic.publicKeyNegate(output, pubkey)
@@ -165,14 +162,7 @@ module.exports = {
     if(!_isSignature(sig)) return 1
 
     try {
-      const res = bitcoinerlab.recover(
-        msg32,
-        sig,
-        recid,
-        isCompressedPublicKey(output)
-      )
-      if (!res) return 1
-      output.set(res)
+      output.set(noble.recoverPublicKey(msg32, sig, recid, isCompressedPublicKey(output)));
     } catch (e) {
       console.error('ecdsaRecover failed', e)
       return 2

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -141,15 +141,4 @@ module.exports = {
       return 1
     }
   },
-  ecdsaRecover: function (output, sig, recid, msg32) {
-    if(!_isSignature(sig)) return 1
-
-    try {
-      output.set(noble.recoverPublicKey(msg32, sig, recid, isCompressedPublicKey(output)));
-    } catch (e) {
-      console.error('ecdsaRecover failed', e)
-      return 2
-    }
-    return 0
-  }
 }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -1,6 +1,31 @@
 // Pre-load elliptic as a backup
 const elliptic = require('./elliptic')
-const noble = require('@noble/secp256k1')
+const necc = require('@noble/secp256k1')
+var hmac = require('@noble/hashes/hmac');
+var sha256 = require('@noble/hashes/sha256');
+
+function _interopNamespaceDefault(e) {
+  var n = Object.create(null);
+  if (e) {
+    Object.keys(e).forEach(function (k) {
+      if (k !== 'default') {
+        var d = Object.getOwnPropertyDescriptor(e, k);
+        Object.defineProperty(n, k, d.get ? d : {
+          enumerable: true,
+          get: function () { return e[k]; }
+        });
+      }
+    });
+  }
+  n.default = e;
+  return Object.freeze(n);
+}
+
+const noble = _interopNamespaceDefault(necc);
+
+noble.utils.hmacSha256Sync = (key, ...msgs) =>
+  hmac.hmac(sha256.sha256, key, noble.utils.concatBytes(...msgs));
+  noble.utils.sha256Sync = (...msgs) => sha256.sha256(noble.utils.concatBytes(...msgs));
 
 const Errors = {
   EXPECTED_PRIVATE: 'Expected Private',
@@ -138,7 +163,22 @@ module.exports = {
     if (noncefn) {
       return elliptic.ecdsaSign(obj, msg32, seckey, data, noncefn)
     }
+
+    
+
     try {
+
+      // if (!noble.utils.isValidPrivateKey(seckey)) {
+      //   return 1
+      // }
+      // if (!isHash(h)) {
+      //   throw new Error(THROW_BAD_SCALAR);
+      // }
+      // if (!isExtraData(e)) {
+      //   throw new Error(THROW_BAD_EXTRA_DATA);
+      // }
+      // const [signature, recoveryId] = noble.signSync(h, d, { der: false, extraEntropy: e, recovered: true });
+      // return { signature, recoveryId }
       const [signature, recoveryId] = noble.signSync(msg32, seckey, { der: false, extraEntropy: data, recovered: true });
       obj.signature.set(signature)
       obj.recid = recoveryId

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -23,6 +23,7 @@ function _interopNamespaceDefault (e) {
 
 const noble = _interopNamespaceDefault(necc)
 
+// Additional Polyfills as per official noble docs https://github.com/paulmillr/noble-secp256k1?tab=readme-ov-file#usage
 noble.utils.hmacSha256Sync = (key, ...msgs) =>
   hmac.hmac(sha256.sha256, key, noble.utils.concatBytes(...msgs))
 noble.utils.sha256Sync = (...msgs) => sha256.sha256(noble.utils.concatBytes(...msgs))
@@ -70,6 +71,7 @@ function _isPoint (p) {
 }
 
 function _isSignature (sig) {
+  if (sig?.length < 64) return false
   const sigObj = { r: sig.slice(0, 32), s: sig.slice(32, 64) }
   const sigr = hexToNumber(noble.utils.bytesToHex(sigObj.r))
   const sigs = hexToNumber(noble.utils.bytesToHex(sigObj.s))

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -71,7 +71,6 @@ function _isPoint (p) {
 }
 
 function _isSignature (sig) {
-  if (sig?.length < 64) throw new Error('Expected signiture length of 64')
   const sigObj = { r: sig.slice(0, 32), s: sig.slice(32, 64) }
   const sigr = hexToNumber(noble.utils.bytesToHex(sigObj.r))
   const sigs = hexToNumber(noble.utils.bytesToHex(sigObj.s))

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -130,6 +130,16 @@ module.exports = {
     }
     return 0
   },
+  ecdsaRecover: function (output, sig, recid, msg32) {
+    if (!_isSignature(sig)) return 1
+    try {
+      output.set(noble.recoverPublicKey(msg32, sig, recid, isCompressedPublicKey(output)))
+    } catch (e) {
+      console.error('ecdsaRecover failed', e)
+      return 2
+    }
+    return 0
+  },
   ecdsaVerify: function (sig, msg32, pubkey) {
     if (!_isSignature(sig)) return 1
     if (!_isPoint(pubkey)) return 2

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -9,7 +9,7 @@ function _interopNamespaceDefault (e) {
   if (e) {
     Object.keys(e).forEach(function (k) {
       if (k !== 'default') {
-        var d = Object.getOwnPropertyDescriptor(e, k)
+        const d = Object.getOwnPropertyDescriptor(e, k)
         Object.defineProperty(n, k, d.get ? d : {
           enumerable: true,
           get: function () { return e[k] }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -1,11 +1,11 @@
 // Pre-load elliptic as a backup
 const elliptic = require('./elliptic')
 const necc = require('@noble/secp256k1')
-var hmac = require('@noble/hashes/hmac')
-var sha256 = require('@noble/hashes/sha256')
+const hmac = require('@noble/hashes/hmac')
+const sha256 = require('@noble/hashes/sha256')
 
 function _interopNamespaceDefault (e) {
-  var n = Object.create(null)
+  const n = Object.create(null)
   if (e) {
     Object.keys(e).forEach(function (k) {
       if (k !== 'default') {
@@ -97,6 +97,7 @@ module.exports = {
         noble.Point.fromHex(pubkey).toRawBytes(isCompressedPublicKey(output))
       )
     } catch (e) {
+      console.error('publicKeyConvert failed', e)
       return 1
     }
     return 0
@@ -136,6 +137,7 @@ module.exports = {
     try {
       return noble.verify(sig, msg32, pubkey) ? 0 : 3
     } catch (e) {
+      console.error('ecdsaVerify failed', e)
       return 1
     }
   }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -71,7 +71,7 @@ function _isPoint (p) {
 }
 
 function _isSignature (sig) {
-  if (sig?.length < 64) return false
+  if (sig?.length < 64) throw new Error('Expected signiture length of 64')
   const sigObj = { r: sig.slice(0, 32), s: sig.slice(32, 64) }
   const sigr = hexToNumber(noble.utils.bytesToHex(sigObj.r))
   const sigs = hexToNumber(noble.utils.bytesToHex(sigObj.s))

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -3,11 +3,12 @@ const elliptic = require('./elliptic')
 const bitcoinerlab = require('@exodus/bitcoinerlab-secp256k1')
 const noble = require('@noble/secp256k1')
 
-const errors = {
+const Errors = {
   EXPECTED_PRIVATE: 'Expected Private',
   EXPECTED_POINT: 'Expected Point',
   EXPECTED_SIGNATURE: 'Expected Signature',
-  INVALID_POINT: 'Point.fromHex: received invalid point.'
+  INVALID_POINT: 'Point.fromHex: received invalid point.',
+  INVALID_SIGNATURE: 'Invalid signature tag'
 }
 
 function isCompressedPublicKey (array) {
@@ -46,6 +47,22 @@ function normalizeScalar(scalar) {
   return num;
 }
 
+function _isPoint(p){
+  try {
+    return !!noble.Point.fromHex(p);
+  } catch (e) {
+    return false;
+  }
+}
+
+function _isSignature(sig){
+  const sigObj = { r: sig.slice(0, 32), s: sig.slice(32, 64) }
+  const sigr = hexToNumber(noble.utils.bytesToHex(sigObj.r))
+  const sigs = hexToNumber(noble.utils.bytesToHex(sigObj.s))
+  if (sigr >= noble.CURVE.n || sigs >= noble.CURVE.n) return false
+  return true
+}
+
 module.exports = {
   contextRandomize: function () {
     // Historically served to randomize the context in constant time, RNG is sufficiently randomized internally.
@@ -65,11 +82,7 @@ module.exports = {
     return elliptic.privateKeyTweakMul(seckey, tweak)
   },
   publicKeyVerify: function (publicKey) {
-    try{
-      noble.Point.fromHex(publicKey);
-      return 0
-    }catch(e){}
-    return 1
+    return _isPoint(publicKey) ? 0 : 1
   },
   publicKeyCreate: function (output, seckey) {
     try {
@@ -88,7 +101,7 @@ module.exports = {
       return 0
     } catch (e) {
       console.error('publicKeyConvert failed', e)
-      if (e.message === errors.EXPECTED_POINT) return 1
+      if (e.message === Errors.EXPECTED_POINT) return 1
       return 2
     }
   },
@@ -107,7 +120,7 @@ module.exports = {
       output.set(Q.toRawBytes(isCompressedPublicKey(output)))
     } catch (e) {
       console.error('publicKeyTweakAdd failed', e)
-      if (e.message.includes(INVALID_POINT)) return 1
+      if (e.message.includes(Errors.INVALID_POINT)) return 1
       return 2
     }
     return 0
@@ -129,7 +142,7 @@ module.exports = {
       return elliptic.ecdsaSign(obj, msg32, seckey, data, noncefn)
     }
     try {
-      const { signature, recoveryId } = bitcoinerlab.signRecoverable(msg32, seckey, data)
+      const [signature, recoveryId] = noble.signSync(msg32, seckey, { der: false, extraEntropy: data, recovered: true });
       obj.signature.set(signature)
       obj.recid = recoveryId
     } catch (e) {
@@ -138,20 +151,18 @@ module.exports = {
     }
     return 0
   },
-  ecdsaVerify: function (signature, message, publicKey) {
+  ecdsaVerify: function (sig, msg32, pubkey) {
+    if(!_isSignature(sig)) return 1
+    if(!_isPoint(pubkey)) return 2
+
     try {
-      return bitcoinerlab.verify(message, publicKey, signature) ? 0 : 3
+      return noble.verify(sig, msg32, pubkey) ? 0 : 3
     } catch (e) {
-      console.error('ecdsaVerify failed', e)
-      if (e.message === errors.EXPECTED_SIGNATURE) return 1
-      return 2
+      return 1
     }
   },
   ecdsaRecover: function (output, sig, recid, msg32) {
-    const sigObj = { r: sig.slice(0, 32), s: sig.slice(32, 64) }
-    const sigr = hexToNumber(noble.utils.bytesToHex(sigObj.r))
-    const sigs = hexToNumber(noble.utils.bytesToHex(sigObj.s))
-    if (sigr >= noble.CURVE.n || sigs >= noble.CURVE.n) return 1
+    if(!_isSignature(sig)) return 1
 
     try {
       const res = bitcoinerlab.recover(

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -13,18 +13,36 @@ function isCompressedPublicKey (array) {
   return array.length === 33
 }
 
-const hexes = Array.from({ length: 256 }, (v, i) => i.toString(16).padStart(2, '0'))
-function bytesToHex (uint8a) {
-  if (!(uint8a instanceof Uint8Array)) { throw new Error('Expected Uint8Array') }
-  let hex = ''
-  for (let i = 0; i < uint8a.length; i++) {
-    hex += hexes[uint8a[i]]
+function hexToNumber(hex) {
+  if (typeof hex !== 'string') {
+    throw new TypeError('hexToNumber: expected string, got ' + typeof hex);
   }
-  return hex
+  return BigInt(`0x${hex}`);
 }
 
-function arrayToBigInt (array) {
-  return BigInt('0x' + bytesToHex(array))
+function normalizeScalar(scalar) {
+  let num;
+  if (typeof scalar === 'bigint') {
+    num = scalar;
+  } else if (
+    typeof scalar === 'number' &&
+    Number.isSafeInteger(scalar) &&
+    scalar >= 0
+  ) {
+    num = BigInt(scalar);
+  } else if (typeof scalar === 'string') {
+    if (scalar.length !== 64)
+      throw new Error('Expected 32 bytes of private scalar');
+    num = hexToNumber(scalar);
+  } else if (scalar instanceof Uint8Array) {
+    if (scalar.length !== 32)
+      throw new Error('Expected 32 bytes of private scalar');
+    num = hexToNumber(noble.utils.bytesToHex(scalar));
+  } else {
+    throw new TypeError('Expected valid private scalar');
+  }
+  if (num < 0) throw new Error('Expected private scalar >= 0');
+  return num;
 }
 
 module.exports = {
@@ -32,54 +50,29 @@ module.exports = {
     // Historically served to randomize the context in constant time, RNG is sufficiently randomized internally.
     return 0
   },
-  privateKeyVerify: function (privateKey) {
-    return bitcoinerlab.isPrivate(privateKey) ? 0 : 1
+  privateKeyVerify: function (seckey) {
+    // tiny-secp256k1 is 2x faster than elliptic, still not noticeable irl
+    return elliptic.privateKeyVerify(seckey)
   },
-  privateKeyNegate: function (privateKey) {
-    try {
-      const res = bitcoinerlab.privateNegate(privateKey)
-      if (!res) return 1
-      privateKey.set(res)
-    } catch (e) {
-      console.error('privateKeyNegate failed, relying on elliptic...', e)
-      elliptic.privateKeyNegate(privateKey)
-    }
-    return 0
+  privateKeyNegate: function (seckey) {
+    return elliptic.privateKeyNegate(seckey)
   },
-  privateKeyTweakAdd: function (privateKey, tweak) {
-    try {
-      const res = bitcoinerlab.privateAdd(privateKey, tweak)
-      if (!res) return 1
-      privateKey.set(res)
-    } catch (e) {
-      console.error('privateKeyTweakAdd failed', e)
-      return 1
-    }
-    return 0
+  privateKeyTweakAdd: function (seckey, tweak) {
+    return elliptic.privateKeyTweakAdd(seckey, tweak)
   },
   privateKeyTweakMul: function (seckey, tweak) {
-    try {
-      const keyNum = noble.utils._normalizePrivateKey(seckey)
-      const tweakNum = noble.utils._normalizePrivateKey(tweak)
-      const res = noble.utils.mod(keyNum * tweakNum, noble.CURVE.n)
-      seckey.set(noble.utils._bigintTo32Bytes(res))
-    } catch (e) {
-      console.error('privateKeyTweakMul failed', e)
-      return 1
-    }
-    return 0
+    return elliptic.privateKeyTweakMul(seckey, tweak)
   },
   publicKeyVerify: function (publicKey) {
-    return bitcoinerlab.isPoint(publicKey) ? 0 : 1
+    try{
+      noble.Point.fromHex(publicKey);
+      return 0
+    }catch(e){}
+    return 1
   },
   publicKeyCreate: function (output, seckey) {
     try {
-      const res = bitcoinerlab.pointFromScalar(
-        seckey,
-        isCompressedPublicKey(output)
-      )
-      if (!res) return 2
-      output.set(res)
+      output.set(noble.getPublicKey(seckey, isCompressedPublicKey(output)))
       return 0
     } catch (e) {
       console.error('publicKeyCreate failed', e)
@@ -99,52 +92,34 @@ module.exports = {
     }
   },
   publicKeyNegate: function (output, pubkey) {
-    try {
-      output.set(
-        noble.Point.fromHex(pubkey)
-          .negate()
-          .toRawBytes(isCompressedPublicKey(output))
-      )
-    } catch (e) {
-      console.error('publicKeyNegate failed', e)
-      return 1
-    }
-    return 0
+    return elliptic.publicKeyNegate(output, pubkey)
   },
   publicKeyCombine: function (output, pubkeys) {
-    try {
-      let point = noble.Point.fromHex(pubkeys[0])
-      for (let i = 1; i < pubkeys.length; ++i) {
-        point = point.add(noble.Point.fromHex(pubkeys[i]))
-      }
-      try {
-        point.assertValidity()
-      } catch (err) {
-        console.error('publicKeyCombine failed', err)
-        return 2
-      }
-      output.set(point.toRawBytes(isCompressedPublicKey(output)))
-    } catch (e) {
-      console.error('publicKeyCombine failed', e)
-      return 1
-    }
-    return 0
+    return elliptic.publicKeyCombine(output, pubkeys)
   },
   publicKeyTweakAdd: function (output, pubkey, tweak) {
     try {
-      const res = bitcoinerlab.pointAddScalar(
-        pubkey,
-        tweak,
-        isCompressedPublicKey(output)
-      )
-      if (!res) return 2
-      output.set(res)
-      return 0
+      const P = noble.Point.fromHex(pubkey);
+      const t = normalizeScalar(tweak);
+      const Q = noble.Point.BASE.multiplyAndAddUnsafe(P, t, BigInt(1));
+      if (!Q) throw new Error('Tweaked point at infinity');
+      output.set(Q.toRawBytes(isCompressedPublicKey(output)))
+
+
+      // const res = bitcoinerlab.pointAddScalar(
+      //   pubkey,
+      //   tweak,
+      //   isCompressedPublicKey(output)
+      // )
+      // if (!res) return 2
+      // output.set(res)
+      // return 0
     } catch (e) {
       console.error('publicKeyTweakAdd failed', e)
       if (e.message === errors.EXPECTED_POINT) return 1
       return 2
     }
+    return 0
   },
   publicKeyTweakMul: function (output, pubkey, tweak) {
     try {
@@ -204,8 +179,8 @@ module.exports = {
   },
   ecdsaRecover: function (output, sig, recid, msg32) {
     const sigObj = { r: sig.slice(0, 32), s: sig.slice(32, 64) }
-    const sigr = arrayToBigInt(sigObj.r)
-    const sigs = arrayToBigInt(sigObj.s)
+    const sigr = hexToNumber(noble.utils.bytesToHex(sigObj.r))
+    const sigs = hexToNumber(noble.utils.bytesToHex(sigObj.s))
     if (sigr >= noble.CURVE.n || sigs >= noble.CURVE.n) return 1
 
     try {

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -113,31 +113,10 @@ module.exports = {
     return 0
   },
   publicKeyTweakMul: function (output, pubkey, tweak) {
-    try {
-      const res = bitcoinerlab.pointMultiply(
-        pubkey,
-        tweak,
-        isCompressedPublicKey(output)
-      )
-      if (!res) return 2
-      output.set(res)
-      return 0
-    } catch (e) {
-      console.error('publicKeyTweakMul failed', e)
-      if (e.message === errors.EXPECTED_POINT) return 1
-      return 2
-    }
+    return elliptic.publicKeyTweakMul(output, pubkey, tweak)
   },
   signatureNormalize: function (sig) {
-    try {
-      sig.set(
-        noble.Signature.fromCompact(sig).normalizeS().toCompactRawBytes()
-      )
-    } catch (e) {
-      console.error('signatureNormalize failed', e)
-      return 1
-    }
-    return 0
+    return elliptic.signatureNormalize(sig)
   },
   signatureExport: function (obj, sig) {
     return elliptic.signatureExport(obj, sig)

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -6,7 +6,8 @@ const noble = require('@noble/secp256k1')
 const errors = {
   EXPECTED_PRIVATE: 'Expected Private',
   EXPECTED_POINT: 'Expected Point',
-  EXPECTED_SIGNATURE: 'Expected Signature'
+  EXPECTED_SIGNATURE: 'Expected Signature',
+  INVALID_POINT: 'Point.fromHex: received invalid point.'
 }
 
 function isCompressedPublicKey (array) {
@@ -102,21 +103,11 @@ module.exports = {
       const P = noble.Point.fromHex(pubkey);
       const t = normalizeScalar(tweak);
       const Q = noble.Point.BASE.multiplyAndAddUnsafe(P, t, BigInt(1));
-      if (!Q) throw new Error('Tweaked point at infinity');
+      if (!Q) return 2
       output.set(Q.toRawBytes(isCompressedPublicKey(output)))
-
-
-      // const res = bitcoinerlab.pointAddScalar(
-      //   pubkey,
-      //   tweak,
-      //   isCompressedPublicKey(output)
-      // )
-      // if (!res) return 2
-      // output.set(res)
-      // return 0
     } catch (e) {
       console.error('publicKeyTweakAdd failed', e)
-      if (e.message === errors.EXPECTED_POINT) return 1
+      if (e.message.includes(INVALID_POINT)) return 1
       return 2
     }
     return 0

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -27,14 +27,6 @@ noble.utils.hmacSha256Sync = (key, ...msgs) =>
   hmac.hmac(sha256.sha256, key, noble.utils.concatBytes(...msgs));
   noble.utils.sha256Sync = (...msgs) => sha256.sha256(noble.utils.concatBytes(...msgs));
 
-const Errors = {
-  EXPECTED_PRIVATE: 'Expected Private',
-  EXPECTED_POINT: 'Expected Point',
-  EXPECTED_SIGNATURE: 'Expected Signature',
-  INVALID_POINT: 'Point.fromHex: received invalid point.',
-  INVALID_SIGNATURE: 'Invalid signature tag'
-}
-
 function isCompressedPublicKey (array) {
   return array.length === 33
 }
@@ -88,23 +80,7 @@ function _isSignature(sig){
 }
 
 module.exports = {
-  contextRandomize: function () {
-    // Historically served to randomize the context in constant time, RNG is sufficiently randomized internally.
-    return 0
-  },
-  privateKeyVerify: function (seckey) {
-    // tiny-secp256k1 is 2x faster than elliptic, still not noticeable irl
-    return elliptic.privateKeyVerify(seckey)
-  },
-  privateKeyNegate: function (seckey) {
-    return elliptic.privateKeyNegate(seckey)
-  },
-  privateKeyTweakAdd: function (seckey, tweak) {
-    return elliptic.privateKeyTweakAdd(seckey, tweak)
-  },
-  privateKeyTweakMul: function (seckey, tweak) {
-    return elliptic.privateKeyTweakMul(seckey, tweak)
-  },
+  ...elliptic,
   publicKeyVerify: function (publicKey) {
     return _isPoint(publicKey) ? 0 : 1
   },
@@ -127,12 +103,6 @@ module.exports = {
     }
     return 0
   },
-  publicKeyNegate: function (output, pubkey) {
-    return elliptic.publicKeyNegate(output, pubkey)
-  },
-  publicKeyCombine: function (output, pubkeys) {
-    return elliptic.publicKeyCombine(output, pubkeys)
-  },
   publicKeyTweakAdd: function (output, pubkey, tweak) {
     try {
       const P = noble.Point.fromHex(pubkey);
@@ -142,43 +112,16 @@ module.exports = {
       output.set(Q.toRawBytes(isCompressedPublicKey(output)))
     } catch (e) {
       console.error('publicKeyTweakAdd failed', e)
-      if (e.message.includes(Errors.INVALID_POINT)) return 1
+      if (e.message.includes('Point.fromHex: received invalid point.')) return 1
       return 2
     }
     return 0
-  },
-  publicKeyTweakMul: function (output, pubkey, tweak) {
-    return elliptic.publicKeyTweakMul(output, pubkey, tweak)
-  },
-  signatureNormalize: function (sig) {
-    return elliptic.signatureNormalize(sig)
-  },
-  signatureExport: function (obj, sig) {
-    return elliptic.signatureExport(obj, sig)
-  },
-  signatureImport: function (output, sig) {
-    return elliptic.signatureImport(output, sig)
   },
   ecdsaSign: function (obj, msg32, seckey, data, noncefn) {
     if (noncefn) {
       return elliptic.ecdsaSign(obj, msg32, seckey, data, noncefn)
     }
-
-    
-
     try {
-
-      // if (!noble.utils.isValidPrivateKey(seckey)) {
-      //   return 1
-      // }
-      // if (!isHash(h)) {
-      //   throw new Error(THROW_BAD_SCALAR);
-      // }
-      // if (!isExtraData(e)) {
-      //   throw new Error(THROW_BAD_EXTRA_DATA);
-      // }
-      // const [signature, recoveryId] = noble.signSync(h, d, { der: false, extraEntropy: e, recovered: true });
-      // return { signature, recoveryId }
       const [signature, recoveryId] = noble.signSync(msg32, seckey, { der: false, extraEntropy: data, recovered: true });
       obj.signature.set(signature)
       obj.recid = recoveryId
@@ -208,8 +151,5 @@ module.exports = {
       return 2
     }
     return 0
-  },
-  ecdh: function (output, pubkey, seckey, data, hashfn, xbuf, ybuf) {
-    return elliptic.ecdh(output, pubkey, seckey, data, hashfn, xbuf, ybuf)
   }
 }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -1,77 +1,75 @@
 // Pre-load elliptic as a backup
 const elliptic = require('./elliptic')
 const necc = require('@noble/secp256k1')
-var hmac = require('@noble/hashes/hmac');
-var sha256 = require('@noble/hashes/sha256');
+var hmac = require('@noble/hashes/hmac')
+var sha256 = require('@noble/hashes/sha256')
 
-function _interopNamespaceDefault(e) {
-  var n = Object.create(null);
+function _interopNamespaceDefault (e) {
+  var n = Object.create(null)
   if (e) {
     Object.keys(e).forEach(function (k) {
       if (k !== 'default') {
-        var d = Object.getOwnPropertyDescriptor(e, k);
+        var d = Object.getOwnPropertyDescriptor(e, k)
         Object.defineProperty(n, k, d.get ? d : {
           enumerable: true,
-          get: function () { return e[k]; }
-        });
+          get: function () { return e[k] }
+        })
       }
-    });
+    })
   }
-  n.default = e;
-  return Object.freeze(n);
+  n.default = e
+  return Object.freeze(n)
 }
 
-const noble = _interopNamespaceDefault(necc);
+const noble = _interopNamespaceDefault(necc)
 
 noble.utils.hmacSha256Sync = (key, ...msgs) =>
-  hmac.hmac(sha256.sha256, key, noble.utils.concatBytes(...msgs));
-  noble.utils.sha256Sync = (...msgs) => sha256.sha256(noble.utils.concatBytes(...msgs));
+  hmac.hmac(sha256.sha256, key, noble.utils.concatBytes(...msgs))
+noble.utils.sha256Sync = (...msgs) => sha256.sha256(noble.utils.concatBytes(...msgs))
 
 function isCompressedPublicKey (array) {
   return array.length === 33
 }
 
-function hexToNumber(hex) {
+function hexToNumber (hex) {
   if (typeof hex !== 'string') {
-    throw new TypeError('hexToNumber: expected string, got ' + typeof hex);
+    throw new TypeError('hexToNumber: expected string, got ' + typeof hex)
   }
-  return BigInt(`0x${hex}`);
+  return BigInt(`0x${hex}`)
 }
 
-function normalizeScalar(scalar) {
-  let num;
+function normalizeScalar (scalar) {
+  let num
   if (typeof scalar === 'bigint') {
-    num = scalar;
+    num = scalar
   } else if (
     typeof scalar === 'number' &&
     Number.isSafeInteger(scalar) &&
     scalar >= 0
   ) {
-    num = BigInt(scalar);
+    num = BigInt(scalar)
   } else if (typeof scalar === 'string') {
-    if (scalar.length !== 64)
-      throw new Error('Expected 32 bytes of private scalar');
-    num = hexToNumber(scalar);
+    if (scalar.length !== 64) { throw new Error('Expected 32 bytes of private scalar') }
+    num = hexToNumber(scalar)
   } else if (scalar instanceof Uint8Array) {
-    if (scalar.length !== 32)
-      throw new Error('Expected 32 bytes of private scalar');
-    num = hexToNumber(noble.utils.bytesToHex(scalar));
+    if (scalar.length !== 32) { throw new Error('Expected 32 bytes of private scalar') }
+    num = hexToNumber(noble.utils.bytesToHex(scalar))
   } else {
-    throw new TypeError('Expected valid private scalar');
+    throw new TypeError('Expected valid private scalar')
   }
-  if (num < 0) throw new Error('Expected private scalar >= 0');
-  return num;
+  if (num < 0) throw new Error('Expected private scalar >= 0')
+  return num
 }
 
-function _isPoint(p){
+function _isPoint (p) {
   try {
-    return !!noble.Point.fromHex(p);
+    return !!noble.Point.fromHex(p)
   } catch (e) {
-    return false;
+    return false
   }
 }
 
-function _isSignature(sig){
+function _isSignature (sig) {
   const sigObj = { r: sig.slice(0, 32), s: sig.slice(32, 64) }
   const sigr = hexToNumber(noble.utils.bytesToHex(sigObj.r))
   const sigs = hexToNumber(noble.utils.bytesToHex(sigObj.s))
@@ -105,9 +103,9 @@ module.exports = {
   },
   publicKeyTweakAdd: function (output, pubkey, tweak) {
     try {
-      const P = noble.Point.fromHex(pubkey);
-      const t = normalizeScalar(tweak);
-      const Q = noble.Point.BASE.multiplyAndAddUnsafe(P, t, BigInt(1));
+      const P = noble.Point.fromHex(pubkey)
+      const t = normalizeScalar(tweak)
+      const Q = noble.Point.BASE.multiplyAndAddUnsafe(P, t, BigInt(1))
       if (!Q) return 2
       output.set(Q.toRawBytes(isCompressedPublicKey(output)))
     } catch (e) {
@@ -122,7 +120,7 @@ module.exports = {
       return elliptic.ecdsaSign(obj, msg32, seckey, data, noncefn)
     }
     try {
-      const [signature, recoveryId] = noble.signSync(msg32, seckey, { der: false, extraEntropy: data, recovered: true });
+      const [signature, recoveryId] = noble.signSync(msg32, seckey, { der: false, extraEntropy: data, recovered: true })
       obj.signature.set(signature)
       obj.recid = recoveryId
     } catch (e) {
@@ -132,13 +130,13 @@ module.exports = {
     return 0
   },
   ecdsaVerify: function (sig, msg32, pubkey) {
-    if(!_isSignature(sig)) return 1
-    if(!_isPoint(pubkey)) return 2
+    if (!_isSignature(sig)) return 1
+    if (!_isPoint(pubkey)) return 2
 
     try {
       return noble.verify(sig, msg32, pubkey) ? 0 : 3
     } catch (e) {
       return 1
     }
-  },
+  }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/secp256k1",
-  "version": "5.0.0-exodus.4",
+  "version": "5.0.0-hybrid.0",
   "description": "This module provides native bindings to ecdsa secp256k1 functions",
   "keywords": [
     "ec",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@noble/secp256k1": "^1.7.1",
+    "@noble/hashes": "^1.1.5",
     "elliptic": "^6.5.2"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@exodus/secp256k1",
-  "version": "5.0.0-hybrid.0",
+  "version": "5.0.0-exodus.4",
   "description": "This module provides native bindings to ecdsa secp256k1 functions",
   "keywords": [
     "ec",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "test": "tape test/index.js | tap-dot"
   },
   "dependencies": {
-    "@exodus/bitcoinerlab-secp256k1": "^1.0.6-rc.1",
     "@noble/secp256k1": "^1.7.1",
     "elliptic": "^6.5.2"
   },


### PR DESCRIPTION

Refactors `bitcoinerlab` usages to raw `noble`, only updates methods which are faster with `noble` not touching `privateKey` operations


<details>
  <summary>Benchmarks</summary>
  

  ### Node results
```
====================================================================================================
Benchmarking function: isPoint
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 59.67 us/op (16758.43 op/s), ±0.40 %
secp256k1@4.0.2 (elliptic): 60.82 us/op (16442.18 op/s), ±1.52 %
noble-secp256k1@1.1.2 (BigInt): 35.68 us/op (28029.27 op/s), ±0.31 %
----------------------------------------------------------------------------------------------------
Fastest: noble-secp256k1@1.1.2 (BigInt)
====================================================================================================
Benchmarking function: isPrivate
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 0.09 us/op (10765820.79 op/s), ±3.08 %
secp256k1@4.0.2 (elliptic): 0.20 us/op (4960935.29 op/s), ±2.41 %
noble-secp256k1@1.1.2 (BigInt): 0.69 us/op (1445387.13 op/s), ±3.74 %
----------------------------------------------------------------------------------------------------
Fastest: tiny-secp256k1@1.1.6 (elliptic)
====================================================================================================
Benchmarking function: pointAdd [publicKeyCombine]
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 528.61 us/op (1891.74 op/s), ±0.40 %
secp256k1@4.0.2 (elliptic): 287.69 us/op (3476.01 op/s), ±0.59 %
noble-secp256k1@1.1.2 (BigInt): 387.36 us/op (2581.57 op/s), ±0.52 %
----------------------------------------------------------------------------------------------------
Fastest: secp256k1@4.0.2 (elliptic)
====================================================================================================
Benchmarking function: pointAddScalar [publicKeyTweakAdd]
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 515.72 us/op (1939.02 op/s), ±1.13 %
secp256k1@4.0.2 (elliptic): 394.87 us/op (2532.47 op/s), ±1.48 %
noble-secp256k1@1.1.2 (BigInt): 346.69 us/op (2884.38 op/s), ±1.23 %
----------------------------------------------------------------------------------------------------
Fastest: noble-secp256k1@1.1.2 (BigInt)
====================================================================================================
Benchmarking function: pointCompress
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 121.24 us/op (8248.25 op/s), ±0.78 %
noble-secp256k1@1.1.2 (BigInt): 107.62 us/op (9291.84 op/s), ±0.44 %
----------------------------------------------------------------------------------------------------
Fastest: noble-secp256k1@1.1.2 (BigInt)
====================================================================================================
Benchmarking function: pointFromScalar
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 304.70 us/op (3281.91 op/s), ±2.07 %
secp256k1@4.0.2 (elliptic): 303.16 us/op (3298.58 op/s), ±1.89 %
noble-secp256k1@1.1.2 (BigInt): 139.33 us/op (7177.38 op/s), ±1.89 %
----------------------------------------------------------------------------------------------------
Fastest: noble-secp256k1@1.1.2 (BigInt)
====================================================================================================
Benchmarking function: pointMultiply
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 269.34 us/op (3712.81 op/s), ±2.41 %
secp256k1@4.0.2 (elliptic): 148.31 us/op (6742.55 op/s), ±2.44 %
noble-secp256k1@1.1.2 (BigInt): 1788.24 us/op (559.21 op/s), ±1.36 %
----------------------------------------------------------------------------------------------------
Fastest: secp256k1@4.0.2 (elliptic)
====================================================================================================
Benchmarking function: privateAdd
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 1.07 us/op (930582.81 op/s), ±0.32 %
secp256k1@4.0.2 (elliptic): 0.87 us/op (1149050.47 op/s), ±0.14 %
noble-secp256k1@1.1.2 (BigInt): 4.34 us/op (230247.98 op/s), ±0.19 %
----------------------------------------------------------------------------------------------------
Fastest: secp256k1@4.0.2 (elliptic)
====================================================================================================
Benchmarking function: privateSub
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 1.12 us/op (890218.05 op/s), ±2.58 %
noble-secp256k1@1.1.2 (BigInt): 4.34 us/op (230458.63 op/s), ±0.72 %
----------------------------------------------------------------------------------------------------
Fastest: tiny-secp256k1@1.1.6 (elliptic)
====================================================================================================
Benchmarking function: privateNegate
----------------------------------------------------------------------------------------------------
noble-secp256k1@1.1.2 (BigInt): 3.63 us/op (275293.57 op/s), ±1.00 %
====================================================================================================
Benchmarking function: sign
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 487.38 us/op (2051.78 op/s), ±0.09 %
secp256k1@4.0.2 (elliptic): 535.90 us/op (1866.04 op/s), ±0.13 %
noble-secp256k1@1.1.2 (BigInt): 205.54 us/op (4865.25 op/s), ±0.24 %
----------------------------------------------------------------------------------------------------
Fastest: noble-secp256k1@1.1.2 (BigInt)
====================================================================================================
Benchmarking function: signRecoverable
----------------------------------------------------------------------------------------------------
====================================================================================================
Benchmarking function: verify
----------------------------------------------------------------------------------------------------
tiny-secp256k1@1.1.6 (elliptic): 1448.14 us/op (690.54 op/s), ±0.36 %
secp256k1@4.0.2 (elliptic): 1280.78 us/op (780.78 op/s), ±0.04 %
noble-secp256k1@1.1.2 (BigInt): 1113.41 us/op (898.14 op/s), ±0.34 %
----------------------------------------------------------------------------------------------------
Fastest: noble-secp256k1@1.1.2 (BigInt)
====================================================================================================
Benchmarking function: recover
----------------------------------------------------------------------------------------------------
====================================================================================================

```

### Hermes results

https://github.com/ExodusMovement/exodus-mobile/tree/ap/elliptic_benchmarks

Ran benchmarks with Hermes:

```
 LOG  privateKeyVerify faster with elliptic
 LOG  privateKeyTweakAdd faster with elliptic
 LOG  publicKeyCreate faster with noble
 LOG  publicKeyConvert faster with noble
 LOG  publicKeyTweakAdd faster with noble
 LOG  ecdsaSign faster with noble
 LOG  ecdsaVerify faster with noble
 ```


```json
{
"elliptic":{
"privateKeyTweakAdd":42.68770799972117,
"privateKeyVerify":8.62020800076425,
"publicKeyConvert":318.7704590000212,
"publicKeyCreate":23780.908802999184,
"publicKeyTweakAdd":86.73329200036824
},
"noble":{
"privateKeyTweakAdd":54.90699999965727,
"privateKeyVerify":25.954375000670552,
"publicKeyConvert":107.60962500050664,
"publicKeyCreate":2842.2172930017114,
"publicKeyTweakAdd":16.500083001330495
}
}
```


The `restore.json` and `launch.json` files where extracted from custom `@exodus/secp256k1` just by adding data to object and then logging it

</details>

